### PR TITLE
fix(api): alias

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.rkoyanagui</groupId>
   <artifactId>elsetility</artifactId>
-  <version>0.1.0</version>
+  <version>0.1.1</version>
 
   <name>elsetility</name>
   <url>https://github.com/rkoyanagui/elsetility</url>

--- a/src/main/java/com/rkoyanagui/core/OrElseFactory.java
+++ b/src/main/java/com/rkoyanagui/core/OrElseFactory.java
@@ -285,8 +285,7 @@ public class OrElseFactory
    */
   public OrElseFactory atMost(final Duration timeout)
   {
-    final ConditionFactory conditionFactory =
-        this.conditionFactory.atMost(timeout);
+    final ConditionFactory conditionFactory = this.conditionFactory.atMost(timeout);
     return new OrElseFactory(conditionFactory, maxAttempts, correctiveAction);
   }
 
@@ -298,8 +297,7 @@ public class OrElseFactory
    */
   public OrElseFactory during(final Duration timeout)
   {
-    final ConditionFactory conditionFactory =
-        this.conditionFactory.during(timeout);
+    final ConditionFactory conditionFactory = this.conditionFactory.during(timeout);
     return new OrElseFactory(conditionFactory, maxAttempts, correctiveAction);
   }
 
@@ -324,8 +322,7 @@ public class OrElseFactory
    */
   public OrElseFactory alias(final String alias)
   {
-    final ConditionFactory conditionFactory =
-        this.conditionFactory.alias(alias);
+    final ConditionFactory conditionFactory = this.conditionFactory.alias(alias);
     return new OrElseFactory(conditionFactory, maxAttempts, correctiveAction);
   }
 
@@ -338,8 +335,7 @@ public class OrElseFactory
    */
   public OrElseFactory atLeast(final Duration timeout)
   {
-    final ConditionFactory conditionFactory =
-        this.conditionFactory.atLeast(timeout);
+    final ConditionFactory conditionFactory = this.conditionFactory.atLeast(timeout);
     return new OrElseFactory(conditionFactory, maxAttempts, correctiveAction);
   }
 
@@ -624,7 +620,7 @@ public class OrElseFactory
    */
   public OrElseFactory await(final String alias)
   {
-    final ConditionFactory conditionFactory = this.conditionFactory.alias(alias);
+    final ConditionFactory conditionFactory = this.conditionFactory.await(alias);
     return new OrElseFactory(conditionFactory, maxAttempts, correctiveAction);
   }
 


### PR DESCRIPTION
Fix await(String) method to have a different implementation from alias(String), now calling ConditionFactory#await(String), instead of ConditionFactory#alias(String).